### PR TITLE
Persist lighting override during menus and add darkness sliders

### DIFF
--- a/ModConfig.cs
+++ b/ModConfig.cs
@@ -7,6 +7,8 @@ namespace NightLight
         public bool NightLightEnabled { get; set; } = true;
         public bool NightLightOutdoors {  get; set; } = true;
         public bool NightLightUnderground { get; set; } = true;
+        public int OutdoorsDarkness { get; set; } = 0;
+        public int UndergroundDarkness { get; set; } = 0;
         public KeybindList NightLightToggleAllKey { get; set; } = KeybindList.Parse("LeftAlt + L");
         public KeybindList NightLightToggleOutdoorsKey { get; set; } = KeybindList.Parse("LeftAlt + O");
         public KeybindList NightLightToggleUndergroundKey { get; set; } = KeybindList.Parse("LeftAlt + U");

--- a/ModEntry.cs
+++ b/ModEntry.cs
@@ -103,23 +103,35 @@ namespace NightLight
         }
 
         private void handleLighting() {
+            if (Game1.currentLocation == null) return;
 
-            // Toggle outdoors lighting
-            if (Config.NightLightOutdoors) {
+            bool isUnderground = Game1.currentLocation.Name.StartsWith("UndergroundMine")
+                || Game1.currentLocation.Name == "FarmCave";
 
-                // Get a reference to the game's ambientLight
-                IReflectedField<Color> ambientLight = this.Helper.Reflection.GetField<Color>(typeof(Game1), "ambientLight");
-                
+            int? darkness = null;
+            if (isUnderground && Config.NightLightUnderground)
+                darkness = Config.UndergroundDarkness;
+            else if (!isUnderground && Config.NightLightOutdoors)
+                darkness = Config.OutdoorsDarkness;
+
+            if (darkness == null || darkness >= 100) return;
+
+            IReflectedField<Color> ambientLight = this.Helper.Reflection.GetField<Color>(typeof(Game1), "ambientLight");
+
+            if (darkness <= 0) {
+                if (isUnderground) Game1.drawLighting = false;
                 ambientLight.SetValue(Color.Transparent);
-
+                return;
             }
 
-            // Toggle lighting within the mines and farm cave
-            if (Config.NightLightUnderground) {
-                if (Game1.currentLocation.Name.StartsWith("UndergroundMine") || Game1.currentLocation.Name == "FarmCave") {
-                    Game1.drawLighting = false;
-                }
-            }
+            Color current = ambientLight.GetValue();
+            float factor = darkness.Value / 100f;
+            ambientLight.SetValue(new Color(
+                (byte)(current.R * factor),
+                (byte)(current.G * factor),
+                (byte)(current.B * factor),
+                (byte)(current.A * factor)
+            ));
         }
 
         private void GameLaunched(object sender, GameLaunchedEventArgs e) {
@@ -170,6 +182,37 @@ namespace NightLight
                 tooltip: () => "Enables light on all floors of the mines (most notable on floors 30-39 of the regular mines) and inside the farm cave.",
                 getValue: () => this.Config.NightLightUnderground,
                 setValue: value => this.Config.NightLightUnderground = value
+            );
+
+            // Section Title For Darkness
+            configMenu.AddSectionTitle(
+                mod: this.ModManifest,
+                text: () => "Darkness Level",
+                tooltip: () => "How much darkness to apply when NightLight is active. 0 = full brightness, 100 = vanilla darkness."
+            );
+
+            // Outdoors Darkness Slider
+            configMenu.AddNumberOption(
+                mod: this.ModManifest,
+                name: () => "Outdoors Darkness",
+                tooltip: () => "How dark the world should appear at night. 0 = full brightness, 100 = vanilla nighttime darkness.",
+                getValue: () => this.Config.OutdoorsDarkness,
+                setValue: value => this.Config.OutdoorsDarkness = value,
+                min: 0,
+                max: 100,
+                interval: 1
+            );
+
+            // Underground Darkness Slider
+            configMenu.AddNumberOption(
+                mod: this.ModManifest,
+                name: () => "Underground Darkness",
+                tooltip: () => "How dark the mines and farm cave should appear. 0 = full brightness, 100 = vanilla underground darkness.",
+                getValue: () => this.Config.UndergroundDarkness,
+                setValue: value => this.Config.UndergroundDarkness = value,
+                min: 0,
+                max: 100,
+                interval: 1
             );
 
             // Section Title For Hotkeys

--- a/ModEntry.cs
+++ b/ModEntry.cs
@@ -33,7 +33,7 @@ namespace NightLight
 
         private void GameUpdated(object? sender, UpdateTickedEventArgs e)
         {
-            if (!Context.IsPlayerFree) return;
+            if (!Context.IsWorldReady) return;
 
             if (Config.NightLightEnabled) {
                 handleLighting();


### PR DESCRIPTION
## Summary
- Fix lighting reverting to nighttime during fishing minigame, inventory/shop menus, and dialogue prompts. The `UpdateTicked` guard was `Context.IsPlayerFree`, which is false in those states, so the ambient override stopped applying and the game's nighttime color bled through. Switched to `Context.IsWorldReady`.
- Replace the binary outdoors/underground overrides with two 0–100 sliders (`OutdoorsDarkness`, `UndergroundDarkness`) exposed via GMCM. `0` preserves the previous full-brightness behavior; `100` leaves vanilla darkness untouched; values between scale the game's current `ambientLight` color toward `Color.Transparent`.
- `handleLighting()` now selects one darkness value per tick based on location, so outdoors and underground modes no longer stack when underground. `drawLighting=false` is kept only at darkness `0` underground (no darkness layer for light sources to punch through).

## Test plan
- [ ] Default config (both sliders at 0) matches previous full-bright behavior outdoors and in mines/farm cave.
- [ ] Open inventory at night outdoors — ambient stays bright (previously reverted).
- [ ] Start a fishing minigame at night — ambient stays bright for the duration.
- [ ] Trigger an NPC dialogue prompt at night — ambient stays bright.
- [ ] Outdoors slider at 50 — visible partial darkness at night, no popping when menus open.
- [ ] Underground slider at 50 in a mines floor — partial darkness with torch/monster lights still cutting through.
- [ ] Slider at 100 — vanilla darkness fully restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)